### PR TITLE
Fix make:model path

### DIFF
--- a/app/Commands/Foundation/ModelMakeCommand.php
+++ b/app/Commands/Foundation/ModelMakeCommand.php
@@ -28,7 +28,7 @@ class ModelMakeCommand extends ModelMake
         $content = $this->getComposer();
         $name    = Str::replaceFirst($this->rootNamespace(), '', $name);
         $path    = getcwd() . $this->devPath();
-        $path    = $content->type === 'project' ? $path . '/app/' : $path;
+        $path    = $content->type === 'project' ? $path . '/app/' : $path . '/src/';
         return  $path . str_replace('\\', '/', $name) . '.php';
     }
 }


### PR DESCRIPTION
Addresses `make:model` command placing new model inside the root directory, not in `/src/` as reported in issue #11.

Kind regards,
g