### PR TITLE
Changing config name to snake case

### DIFF
--- a/app/Commands/Standalone/Config.php
+++ b/app/Commands/Standalone/Config.php
@@ -29,7 +29,7 @@ class Config extends MakeFile
 
     public function getFilename()
     {
-        return Str::studly(cache()->get('package_name')) . '.php';
+        return Str::snake(cache()->get('package_name')) . '.php';
     }
 
     public function getPath()


### PR DESCRIPTION
Hi bitfumes,
Things bugging me while using this package is, it's naming config name into StudlyCase case.
According laravel naming standard it really shouldn't,
as far as i concern config name should be lowercased
I have made this PR changing config name from `StudyCase` to `snake_case`.