### PR TITLE
Fix migration path on non-development environment

### DIFF
--- a/app/Commands/Foundation/Migrations/MigrationCreator.php
+++ b/app/Commands/Foundation/Migrations/MigrationCreator.php
@@ -34,6 +34,6 @@ class MigrationCreator extends RealMigrationCreator
             $this->files->makeDirectory($path, 0777, true);
         }
 
-        return $path . '/' . $this->getDatePrefix() . '_' . $name . '.php';
+        return str_replace('//', '/', $path) . '/' . $this->getDatePrefix() . '_' . $name . '.php';
     }
 }

--- a/app/Commands/Foundation/Migrations/MigrationCreator.php
+++ b/app/Commands/Foundation/Migrations/MigrationCreator.php
@@ -26,9 +26,10 @@ class MigrationCreator extends RealMigrationCreator
     {
         $devPath = '';
         if (app()->environment() === 'development') {
-            $devPath = $this->devPath() . 'src/';
+            $devPath = $this->devPath() . 'src';
         }
-        $path = getcwd() . $devPath . 'database/migrations';
+
+        $path = getcwd() . $devPath . '/database/migrations';
         if (!$this->files->isDirectory($path)) {
             $this->files->makeDirectory($path, 0777, true);
         }


### PR DESCRIPTION
Hi! I'm use Packr v4.7.5

The generated migration does not end up in the expected directory. 

![Снимок экрана от 2021-10-17 00 38 44](https://user-images.githubusercontent.com/8027278/137602725-226531c6-5489-4282-a50e-77c72886caf6.png)

Call "getcwd" returned result without last directory separator:
![Снимок экрана от 2021-10-17 01 02 40](https://user-images.githubusercontent.com/8027278/137603167-ceecebfb-65bd-42ee-bc57-224ca4072db7.png)


